### PR TITLE
Getters have other getters as second parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ const useRootNamespace = { root: true }
 
 export type MutationHandler<S, P> = (state: S, payload: P) => void
 export type ActionHandler<S, R, P, T> = (context: BareActionContext<S, R>, payload: P) => Promise<T> | T
-export type GetterHandler<S, R, T> = (state: S, rootState: R) => T
+export type GetterHandler<S, R, T> = (state: S, getters: any, rootState: R) => T
 
 
 interface Dictionary<T> { [key: string]: T }


### PR DESCRIPTION
As per https://vuex.vuejs.org/guide/modules.html#module-local-state, getters have the other getters of module as second parameter