### PR TITLE
Add typings file from dist to the package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.7",
   "description": "A TypeScript pattern for strongly-typed access to Vuex Store modules",
   "files": [
+    "dist/index.d.ts",
     "dist/index.js",
     "dist/index.js.map"
   ],


### PR DESCRIPTION
After the work done in https://github.com/mrcrowl/vuex-typex/pull/36 the typings were missed in the published npm package. I have added the dist index.d.ts file to the package files list so it will be published to npm.